### PR TITLE
jenkins-build: Tidy CentOS7 lsb_release output (rebased onto develop)

### DIFF
--- a/scripts/jenkins-build
+++ b/scripts/jenkins-build
@@ -15,7 +15,7 @@ os_version() {
 
   case "$system" in
       Linux*)
-          echo "$(lsb_release -si | sed -e 's;[[:space:]]*;;g')$(lsb_release -sr | sed -e 's;[[:space:]]*;;g')-$machine"
+          echo "$(lsb_release -si | sed -e 's;[[:space:]]*;;g')$(lsb_release -sr | sed -e 's;[[:space:]]*;;g' | sed -e 's;^\([^.][^.]*\)\.\([^.][^.]*\).*;\1.\2;')-$machine"
           ;;
       FreeBSD*)
           echo "$(freebsd-version | sed -e 's;\([^-]*\)-.*;FreeBSD\1;')-$machine"


### PR DESCRIPTION
This is the same as gh-20 but rebased onto develop.

---

It includes much more than the major and minor version, so trim the
unwanted part.

---

Testing: Check the archive name under https://ci.openmicroscopy.org/job/BIOFORMATS-CPP-5.1-merge-superbuild/BUILD_TYPE=Release,CXXSTD_AUTODETECT=ON,node=cowfish/lastSuccessfulBuild/artifact/artefacts/superbuild/

The name should include `CentOS7.1-x86_64`.
