### PR TITLE
xerces: Version 3.1.3

### DIFF
--- a/packages/xerces/superbuild.cmake
+++ b/packages/xerces/superbuild.cmake
@@ -18,8 +18,8 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${EP_PROJECT})
 
   ExternalProject_Add(${EP_PROJECT}
     ${BIOFORMATS_EP_COMMON_ARGS}
-    URL "http://www.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.2.tar.xz"
-    URL_HASH "SHA512=d4517d80f6f0ec462982a0327f10bbd96206c0f24adc6d32e4482ad07b48be7404d8923fc6c8172ebdfa8ae0c5f403eea9db4b62f8263aa017e67889b1869cd8"
+    URL "http://www.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.3.tar.xz"
+    URL_HASH "SHA512=9931fbf2c91ba2dcb36e5909486c9fc7532420d6f692b1bb24fc93abf3cc67fbd3c9e2ffd443645c93013634000e0bca3ac2ba7ff298d4f5324db9d4d1340600"
     SOURCE_DIR "${EP_SOURCE_DIR}"
     BINARY_DIR "${EP_BINARY_DIR}"
     INSTALL_DIR ""
@@ -51,3 +51,4 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${EP_PROJECT})
 else()
   ome_add_empty_project(${EP_PROJECT})
 endif()
+


### PR DESCRIPTION
--rebased-from #40 

Version 3.1.2 is removed from the mirror. The new release fixes a couple of bugs. https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=10510&version=12332290

Testing: Check jobs are green.
