### PR TITLE
Bump OME-XML version to 5.2.2

### DIFF
--- a/packages/ome-xml/superbuild.cmake
+++ b/packages/ome-xml/superbuild.cmake
@@ -7,8 +7,8 @@ set(ome-xml-git-url "" CACHE STRING "URL of OME-XML [Bio-Formats] git repository
 set(ome-xml-git-branch "" CACHE STRING "URL of OME-XML [Bio-Formats] git repository")
 
 # Current stable release.
-set(RELEASE_URL "http://downloads.openmicroscopy.org/bio-formats/5.2.0-m5/artifacts/bioformats-dfsg-5.2.0-m5.tar.xz")
-set(RELEASE_HASH "SHA512=7f9fa74dde9959569d10cbbb028e58b354648074e86ac52ef2ffc280e1801c130928aacbbfc1a085da028dc9a77eee54d1958f804dd066bb4b71030e4c044429")
+set(RELEASE_URL "http://downloads.openmicroscopy.org/bio-formats/5.2.2/artifacts/bioformats-dfsg-5.2.2.tar.xz")
+set(RELEASE_HASH "SHA512=b780b2921adee67a1ae420dfe95f1cd3e3c76ee170a118abe995209ba8e4697a011510e0d225a756d03a642d4c925167c995f39756f38b4a106f31b586a1ed23")
 
 # Current development branch (defaults for ome-xml-head option).
 set(GIT_URL "https://github.com/openmicroscopy/bioformats.git")


### PR DESCRIPTION
Following the release of Bio-Formats 5.2.2 (including C++ fixes), this should bump the superbuild package requirements to consume the source release.
