### PR TITLE
jenkins-build: Handle sw_vers output on MacOS X 10.12

### DIFF
--- a/scripts/jenkins-build
+++ b/scripts/jenkins-build
@@ -21,7 +21,7 @@ os_version() {
           echo "$(freebsd-version | sed -e 's;\([^-]*\)-.*;FreeBSD\1;')-$machine"
           ;;
       Darwin*)
-          echo "$(sw_vers | grep ^ProductVersion: | sed -e 's;^ProductVersion:[[:space:]]*\(.*\)\.\(.*\)\.\(.*\);MacOSX\1.\2;')-$machine"
+          echo "$(sw_vers | grep ^ProductVersion: | sed -e 's;^ProductVersion:[[:space:]]*\(.*\)\.\(.*\)\(\..*\)*;MacOSX\1.\2;')-$machine"
           ;;
       *)
           echo "$(uname -sr | sed -e 's;[[:space:]]*;;g')-$machine"


### PR DESCRIPTION
This new version drops the third digit from the output.  Update the regex to make it optional.

Testing: The superbuild and platform builds will go green, and the filenames will have 10.12 in the name.

https://ci.openmicroscopy.org/view/Files/job/OME-FILES-CPP-DEV-merge-superbuild/ - node sole
https://ci.openmicroscopy.org/view/Files/job/OME-FILES-CPP-DEV-merge/ - node snipe
