### PR TITLE
sphinx: Drop PDF building

### DIFF
--- a/Options.cmake
+++ b/Options.cmake
@@ -76,25 +76,7 @@ option(doxygen "Enable doxygen documentation" ${DOXYGEN_DEFAULT})
 set(BUILD_DOXYGEN ${doxygen})
 
 # Sphinx documentation generator
-find_program(XELATEX xelatex)
-if (XELATEX)
-  message(STATUS "Looking for xelatex - ${XELATEX}")
-else()
-  message(STATUS "Looking for xelatex - not found")
-endif()
-find_program(MAKEINDEX makeindex)
-if (MAKEINDEX)
-  message(STATUS "Looking for makeindex - ${MAKEINDEX}")
-else()
-  message(STATUS "Looking for makeindex - not found")
-endif()
-
 option(sphinx "Enable sphinx manual page and HTML documentation" ON)
-set(SPHINX_PDF_DEFAULT OFF)
-if(XELATEX AND MAKEINDEX)
-  set(SPHINX_PDF_DEFAULT ON)
-endif()
-option(sphinx-pdf "Enable sphinx PDF documentation" ${SPHINX_PDF_DEFAULT})
 option(sphinx-linkcheck "Check sphinx documentation links by default" OFF)
 
 set(SUPERBUILD_OPTIONS
@@ -105,5 +87,4 @@ set(SUPERBUILD_OPTIONS
     "-Dextended-tests:BOOL=${extended-tests}"
     "-Ddoxygen:BOOL=${doxygen}"
     "-Dsphinx:BOOL=${sphinx}"
-    "-Dsphinx-pdf:BOOL=${sphinx-pdf}"
     "-Dsphinx-linkcheck:BOOL=${sphinx-linkcheck}")

--- a/cmake/Sphinx.cmake
+++ b/cmake/Sphinx.cmake
@@ -35,7 +35,6 @@
 # #L%
 
 set(BUILD_SPHINX ${sphinx})
-set(BUILD_SPHINX_PDF ${sphinx-pdf})
 
 function(sphinx_manpages srcdir confdir mandir manvar)
   execute_process(COMMAND python -B ${PROJECT_SOURCE_DIR}/cmake/list-manpages.py

--- a/docs/sphinx/CMakeLists.txt
+++ b/docs/sphinx/CMakeLists.txt
@@ -111,39 +111,6 @@ if (BUILD_SPHINX AND SPHINX_BUILD)
                      COMMENT "Checking local links in sphinx documentation"
                      WORKING_DIRECTORY "${sphinx_srcdir}"
                      DEPENDS doc-remotelinkcheck)
-
-  # Generate and install PDF manual
-
-  if (BUILD_SPHINX_PDF AND XELATEX AND MAKEINDEX)
-    set(texprefix "OME-CMake-Super-Build")
-    add_custom_command(OUTPUT "${sphinx_builddir}/latex/${texprefix}.tex" "${sphinx_builddir}/latex/preamble.tex"
-                       COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/cache"
-                       COMMAND ${CMAKE_COMMAND} -E make_directory "${sphinx_builddir}/latex"
-                       COMMAND ${SPHINX_BUILD}
-                               -D "release=${DOC_VERSION_MAJOR}.${DOC_VERSION_MINOR}.${DOC_VERSION_PATCH}"
-                               -D "version=${DOC_VERSION_MAJOR}.${DOC_VERSION_MINOR}"
-                               -c "${sphinx_builddir}"
-                               -d "${sphinx_builddir}/cache"
-                               -b latex
-                               "${sphinx_srcdir}" "${sphinx_builddir}/latex"
-                       COMMAND ${CMAKE_COMMAND} -E copy "preamble.tex" "${sphinx_builddir}/latex"
-                       WORKING_DIRECTORY "${sphinx_srcdir}"
-                       DEPENDS ${SPHINX_DEPENDENCIES})
-    add_custom_command(OUTPUT "${sphinx_builddir}/latex/${texprefix}.pdf"
-                       COMMAND ${XELATEX} "${texprefix}.tex"
-                       COMMAND ${XELATEX} "${texprefix}.tex"
-                       COMMAND ${MAKEINDEX} -s python.ist "${texprefix}.idx"
-                       COMMAND ${XELATEX} "${texprefix}.tex"
-                       COMMAND ${XELATEX} "${texprefix}.tex"
-                       COMMAND ${XELATEX} "${texprefix}.tex"
-                       WORKING_DIRECTORY "${sphinx_builddir}/latex"
-                       DEPENDS "${sphinx_builddir}/latex/${texprefix}.tex" "${sphinx_builddir}/latex/preamble.tex")
-
-    add_custom_target(doc-pdf ALL DEPENDS "${sphinx_builddir}/latex/${texprefix}.pdf")
-
-    install(FILES "${sphinx_builddir}/latex/${texprefix}.pdf"
-            DESTINATION "${CMAKE_INSTALL_DOCDIR}/manual")
-  endif (BUILD_SPHINX_PDF AND XELATEX AND MAKEINDEX)
 else()
   message(WARNING "Manual pages and HTML manual will not be generated or installed")
 endif()

--- a/docs/sphinx/building.rst
+++ b/docs/sphinx/building.rst
@@ -35,8 +35,7 @@ configurations may be selected for different projects.
 - Activate a python virtualenv if needed
 - Ensure that needed tools are on the user :envvar:`PATH`
   (e.g. :program:`cmake`, :program:`doxygen`, :program:`dot`,
-  :program:`git`, :program:`python`, :program:`sphinx`,
-  :program:`xelatex`)
+  :program:`git`, :program:`python`, :program:`sphinx`)
 - Set ``CMAKE_PREFIX_PATH`` if some libraries and tools are not on the
   default search path.  Not all tools need to be on the default path;
   some will be discovered automatically by :program:`cmake`
@@ -134,9 +133,6 @@ relocatable-install=(ON|OFF)
 sphinx=(ON|OFF)
   Build manual pages and HTML documentation with Sphinx.  Enabled by
   default if Sphinx is autodetected.
-sphinx-pdf=(ON|OFF)
-  Build PDF documentation with Sphinx.  Enabled by default if Sphinx
-  and XeLaTeX are autodetected.
 test=(ON|OFF)
   Enable unit tests.  Tests are enabled by default.
 xsdfu-debug=(ON|OFF)

--- a/scripts/jenkins-build
+++ b/scripts/jenkins-build
@@ -141,7 +141,6 @@ build() {
             -Dparallel:BOOL="$parallel_opt" \
             -Dsphinx:BOOL=ON \
             "-Dsphinx-linkcheck:BOOL=${linkcheck}" \
-            -Dsphinx-pdf:BOOL=OFF \
             -Dsource-cache:PATH=${cachedir}/source \
             -Dtool-cache:PATH=${cachedir}/tools \
             -DSOURCE_ARCHIVE_DIR="${artefactdir}/sources" \

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -340,7 +340,6 @@ if [%build_system%] == [MSBuild] (
       -Dbuild-packages=%packages% ^
       -Dparallel:BOOL=%parallel_opt% ^
       -Dsphinx:BOOL=ON ^
-      -Dsphinx-pdf:BOOL=OFF ^
       -Dsphinx-linkcheck:BOOL=%linkcheck% ^
       -Dsource-cache:PATH=%cachedir%\source ^
       -Dtool-cache:PATH=%cachedir%\tools ^
@@ -393,7 +392,6 @@ if [%build_system%] == [Ninja] (
       -Dbuild-packages=%packages% ^
       -Dparallel:BOOL=%parallel_opt% ^
       -Dsphinx:BOOL=ON ^
-      -Dsphinx-pdf:BOOL=OFF ^
       -Dsphinx-linkcheck:BOOL=%linkcheck% ^
       -Dsource-cache:PATH=%cachedir%\source ^
       -Dtool-cache:PATH=%cachedir%\tools ^


### PR DESCRIPTION
Remove support for building PDF documentation.

Testing: Check builds are green and that the docs are OK.