### PR TITLE
Add git-dir option and simplify OME component source download definitions

### DIFF
--- a/Options.cmake
+++ b/Options.cmake
@@ -59,6 +59,9 @@ option(extended-tests "Enable extended tests (more comprehensive, longer run tim
 # stage directory in the build tree.
 option(relocatable-install "Install tree will be relocatable" ON)
 
+# Default location of git repositories
+set(git-dir "" CACHE STRING "Default location of local git repositories")
+
 option(head "Force building from current git develop branch (all OME components)" OFF)
 
 # List of packages to build

--- a/docs/sphinx/building.rst
+++ b/docs/sphinx/building.rst
@@ -478,6 +478,11 @@ out.  Run::
     make
     make install
 
+Note that if all the git repositories are in a common location and use
+their canonical names, then this may be simplified::
+
+    cmake -G Ninja -Dgit-dir=/path/to/git/repos -Dbuild-prerequisites=OFF -Dome-superbuild_BUILD_gtest=ON -Dbuild-packages=ome-qtwidgets -DCMAKE_INSTALL_PREFIX=/install/dir /path/to/superbuild/git/repo
+
 Building OME Files on Windows (release)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -513,3 +518,8 @@ clone has the branch you wish to build checked out.  Run::
     cmake -G Ninja -Dome-common-dir=/path/to/ome-common-cpp -Dome-model-dir=/path/to/ome-model -Dome-files-dir=/path/to/ome-files -Dome-qtwidgets-dir=/path/to/ome-qtwidgets -Dbuild-packages=ome-qtwidgets -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/install/dir /path/to/superbuild/sources
     ninja
     ninja install
+
+Note that if all the git repositories are in a common location and use
+their canonical names, then this may be simplified::
+
+    cmake -G Ninja -Dgit-dir=/path/to/git/repos -Dbuild-packages=ome-qtwidgets -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/install/dir /path/to/superbuild/sources

--- a/packages/ome-common/superbuild.cmake
+++ b/packages/ome-common/superbuild.cmake
@@ -1,45 +1,13 @@
 # ome-common superbuild
 
-# Options to build from git (defaults to source zip if unset)
-set(ome-common-head ${head} CACHE BOOL "Force building from current git develop branch")
-set(ome-common-dir "" CACHE PATH "Local directory containing the OME Common C++ source code")
-set(ome-common-git-url "" CACHE STRING "URL of OME Common C++ git repository")
-set(ome-common-git-branch "" CACHE STRING "URL of OME Common C++ git repository")
-
-# Current stable release.
-set(RELEASE_URL "https://downloads.openmicroscopy.org/ome-common-cpp/5.3.2/source/ome-common-cpp-5.3.2.tar.xz")
-set(RELEASE_HASH "SHA512=09ba994a70623df4c07f6790875cc33a677db735c5883d495ab30124963591facb0ab7b5fc0e6c5a2db257bab76f0871b2b7c52a595ebbc972699ec917f87f1a")
-
-# Current development branch (defaults for ome-common-head option).
-set(GIT_URL "https://github.com/ome/ome-common-cpp.git")
-set(GIT_BRANCH "develop")
-
-if(NOT ome-common-head)
-  if(ome-common-git-url)
-    set(GIT_URL ${ome-common-git-url})
-  endif()
-  if(ome-common-git-branch)
-    set(GIT_BRANCH ${ome-common-git-branch})
-  endif()
-endif()
-
-if(ome-common-dir)
-  set(EP_SOURCE_DOWNLOAD
-    DOWNLOAD_COMMAND "")
-  set(EP_SOURCE_DIR "${ome-common-dir}")
-  message(STATUS "Building OME Common C++ from local directory (${ome-common-dir})")
-elseif(ome-common-head OR ome-common-git-url OR ome-common-git-branch)
-  set(EP_SOURCE_DOWNLOAD
-    GIT_REPOSITORY "${GIT_URL}"
-    GIT_TAG "${GIT_BRANCH}"
-    UPDATE_DISCONNECTED 1)
-  message(STATUS "Building OME Common C++ from git (URL ${GIT_URL}, branch/tag ${GIT_BRANCH})")
-else()
-  set(EP_SOURCE_DOWNLOAD
-    URL "${RELEASE_URL}"
-    URL_HASH "${RELEASE_HASH}")
-  message(STATUS "Building OME Common C++ from source release (${RELEASE_URL})")
-endif()
+# Source information
+ome_source_settings(ome-common
+  NAME            "OME Common C++"
+  GIT_NAME        "ome-common-cpp"
+  GIT_URL         "https://github.com/ome/ome-common-cpp.git"
+  GIT_HEAD_BRANCH "master"
+  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-common-cpp/5.3.2/source/ome-common-cpp-5.3.2.tar.xz"
+  RELEASE_HASH    "SHA512=09ba994a70623df4c07f6790875cc33a677db735c5883d495ab30124963591facb0ab7b5fc0e6c5a2db257bab76f0871b2b7c52a595ebbc972699ec917f87f1a")
 
 # Set dependency list
 ome_add_dependencies(ome-common THIRD_PARTY_DEPENDENCIES boost gtest xerces xalan)

--- a/packages/ome-files/superbuild.cmake
+++ b/packages/ome-files/superbuild.cmake
@@ -1,45 +1,13 @@
 # ome-files superbuild
 
-# Options to build from git (defaults to source zip if unset)
-set(ome-files-head ${head} CACHE BOOL "Force building from current git develop branch")
-set(ome-files-dir "" CACHE PATH "Local directory containing the OME Files source code")
-set(ome-files-git-url "" CACHE STRING "URL of OME Files git repository")
-set(ome-files-git-branch "" CACHE STRING "URL of OME Files git repository")
-
-# Current stable release.
-set(RELEASE_URL "https://downloads.openmicroscopy.org/ome-files-cpp/0.2.3/source/ome-files-cpp-0.2.3.tar.xz")
-set(RELEASE_HASH "SHA512=8d7cc123a3f32f363fb573529222f4d4c47dc16e8cc3f7a8e42a1592018971f4a8bf3c87b83ced3b4f5cda2dc58cdc7a40bf8b9215fe2b02ace9b589b04ab635")
-
-# Current development branch (defaults for ome-files-head option).
-set(GIT_URL "https://github.com/ome/ome-files.git")
-set(GIT_BRANCH "develop")
-
-if(NOT ome-files-head)
-  if(ome-files-git-url)
-    set(GIT_URL ${ome-files-git-url})
-  endif()
-  if(ome-files-git-branch)
-    set(GIT_BRANCH ${ome-files-git-branch})
-  endif()
-endif()
-
-if(ome-files-dir)
-  set(EP_SOURCE_DOWNLOAD
-    DOWNLOAD_COMMAND "")
-  set(EP_SOURCE_DIR "${ome-files-dir}")
-  message(STATUS "Building OME Files C++ from local directory (${ome-files-dir})")
-elseif(ome-files-head OR ome-files-git-url OR ome-files-git-branch)
-  set(EP_SOURCE_DOWNLOAD
-    GIT_REPOSITORY "${GIT_URL}"
-    GIT_TAG "${GIT_BRANCH}"
-    UPDATE_DISCONNECTED 1)
-  message(STATUS "Building OME Files C++ from git (URL ${GIT_URL}, branch/tag ${GIT_BRANCH})")
-else()
-  set(EP_SOURCE_DOWNLOAD
-    URL "${RELEASE_URL}"
-    URL_HASH "${RELEASE_HASH}")
-  message(STATUS "Building OME Files C++ from source release (${RELEASE_URL})")
-endif()
+# Source information
+ome_source_settings(ome-files
+  NAME            "OME Files C++"
+  GIT_NAME        "ome-files-cpp"
+  GIT_URL         "https://github.com/ome/ome-files-cpp.git"
+  GIT_HEAD_BRANCH "master"
+  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-files-cpp/0.2.3/source/ome-files-cpp-0.2.3.tar.xz"
+  RELEASE_HASH    "SHA512=8d7cc123a3f32f363fb573529222f4d4c47dc16e8cc3f7a8e42a1592018971f4a8bf3c87b83ced3b4f5cda2dc58cdc7a40bf8b9215fe2b02ace9b589b04ab635")
 
 # Set dependency list
 ome_add_dependencies(ome-files

--- a/packages/ome-model/superbuild.cmake
+++ b/packages/ome-model/superbuild.cmake
@@ -1,45 +1,13 @@
 # ome-model superbuild
 
-# Options to build from git (defaults to source zip if unset)
-set(ome-model-head ${head} CACHE BOOL "Force building from current git develop branch")
-set(ome-model-dir "" CACHE PATH "Local directory containing the OME Model source code")
-set(ome-model-git-url "" CACHE STRING "URL of OME Model git repository")
-set(ome-model-git-branch "" CACHE STRING "URL of OME Model git repository")
-
-# Current stable release.
-set(RELEASE_URL "")
-set(RELEASE_HASH "SHA512=")
-
-# Current development branch (defaults for ome-model-head option).
-set(GIT_URL "https://github.com/ome/ome-model.git")
-set(GIT_BRANCH "master")
-
-if(NOT ome-model-head)
-  if(ome-model-git-url)
-    set(GIT_URL ${ome-model-git-url})
-  endif()
-  if(ome-model-git-branch)
-    set(GIT_BRANCH ${ome-model-git-branch})
-  endif()
-endif()
-
-if(ome-model-dir)
-  set(EP_SOURCE_DOWNLOAD
-    DOWNLOAD_COMMAND "")
-  set(EP_SOURCE_DIR "${ome-model-dir}")
-  message(STATUS "Building OME Model C++ from local directory (${ome-model-dir})")
-elseif(ome-model-head OR ome-model-git-url OR ome-model-git-branch)
-  set(EP_SOURCE_DOWNLOAD
-    GIT_REPOSITORY "${GIT_URL}"
-    GIT_TAG "${GIT_BRANCH}"
-    UPDATE_DISCONNECTED 1)
-  message(STATUS "Building OME Model C++ from git (URL ${GIT_URL}, branch/tag ${GIT_BRANCH})")
-else()
-  set(EP_SOURCE_DOWNLOAD
-    URL "${RELEASE_URL}"
-    URL_HASH "${RELEASE_HASH}")
-  message(STATUS "Building OME Model C++ from source release (${RELEASE_URL})")
-endif()
+# Source information
+ome_source_settings(ome-model
+  NAME            "OME Model"
+  GIT_NAME        "ome-model"
+  GIT_URL         "https://github.com/ome/ome-model.git"
+  GIT_HEAD_BRANCH "master"
+  RELEASE_URL     ""
+  RELEASE_HASH    "SHA512=")
 
 # Set dependency list
 ome_add_dependencies(ome-model

--- a/packages/ome-qtwidgets/superbuild.cmake
+++ b/packages/ome-qtwidgets/superbuild.cmake
@@ -1,45 +1,13 @@
 # ome-qtwidgets superbuild
 
-# Options to build from git (defaults to source zip if unset)
-set(ome-qtwidgets-head ${head} CACHE BOOL "Force building from current git develop branch")
-set(ome-qtwidgets-dir "" CACHE PATH "Local directory containing the OME QtWidgets source code")
-set(ome-qtwidgets-git-url "" CACHE STRING "URL of OME QtWidgets git repository")
-set(ome-qtwidgets-git-branch "" CACHE STRING "URL of OME QtWidgets git repository")
-
-# Current stable release.
-set(RELEASE_URL "https://downloads.openmicroscopy.org/ome-qtwidgets/5.3.2/source/ome-qtwidgets-5.3.2.tar.xz")
-set(RELEASE_HASH "SHA512=ab9c3b745cdf409b977076853d227ccc65ca45b3977a373e65661f65ae101a2d11ff34328205bbc5693b219ef0b8f12f0536ef5652a7bb205e3f142e35bd1477")
-
-# Current development branch (defaults for ome-qtwidgets-head option).
-set(GIT_URL "https://github.com/ome/ome-qtwidgets.git")
-set(GIT_BRANCH "develop")
-
-if(NOT ome-qtwidgets-head)
-  if(ome-qtwidgets-git-url)
-    set(GIT_URL ${ome-qtwidgets-git-url})
-  endif()
-  if(ome-qtwidgets-git-branch)
-    set(GIT_BRANCH ${ome-qtwidgets-git-branch})
-  endif()
-endif()
-
-if(ome-qtwidgets-dir)
-  set(EP_SOURCE_DOWNLOAD
-    DOWNLOAD_COMMAND "")
-  set(EP_SOURCE_DIR "${ome-qtwidgets-dir}")
-  message(STATUS "Building OME QtWidgets C++ from local directory (${ome-qtwidgets-dir})")
-elseif(ome-qtwidgets-head OR ome-qtwidgets-git-url OR ome-qtwidgets-git-branch)
-  set(EP_SOURCE_DOWNLOAD
-    GIT_REPOSITORY "${GIT_URL}"
-    GIT_TAG "${GIT_BRANCH}"
-    UPDATE_DISCONNECTED 1)
-  message(STATUS "Building OME QtWidgets C++ from git (URL ${GIT_URL}, branch/tag ${GIT_BRANCH})")
-else()
-  set(EP_SOURCE_DOWNLOAD
-    URL "${RELEASE_URL}"
-    URL_HASH "${RELEASE_HASH}")
-  message(STATUS "Building OME QtWidgets C++ from source release (${RELEASE_URL})")
-endif()
+# Source information
+ome_source_settings(ome-qtwidgets
+  NAME            "OME QtWidgets"
+  GIT_NAME        "ome-qtwidgets"
+  GIT_URL         "https://github.com/ome/ome-qtwidgets.git"
+  GIT_HEAD_BRANCH "master"
+  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-qtwidgets/5.3.2/source/ome-qtwidgets-5.3.2.tar.xz"
+  RELEASE_HASH    "SHA512=ab9c3b745cdf409b977076853d227ccc65ca45b3977a373e65661f65ae101a2d11ff34328205bbc5693b219ef0b8f12f0536ef5652a7bb205e3f142e35bd1477")
 
 # Set dependency list
 ome_add_dependencies(ome-qtwidgets


### PR DESCRIPTION
- Refactor to simplify the logic in each superbuild component into a central helper function.
- Add a `git-dir` option to default the various `component-dir` options.

Essentially, while before you might have needed `-Dome-common-dir=/path/to/ome-common -Dome-model-dir=/path/to/ome-model -Dome-files-dir=/path/to/ome-files -Dome-qtwidgets-dir=/path/to/ome-qtwidgets`, you can now use `-Dgit-dir=/path/to/git/repos` which is much easier to use and vastly less error prone.  All the old options continue to exist; they override `git-dir`'s default.  This makes development with all the split repositories much easier, and it also makes maintenance easier as we add more components.

Testing: Check jobs are green.  If you would like to test the settings, then you can run

`cmake -Dgit-dir=/path/to/git/repos /path/to/this/superbuild/pr` and check which repositories it will build.  You need ome-common-cpp, ome-model, ome-files-cpp and ome-qtwidgets cloned into this location before doing this.  Then run make, and check the components are built.

If you wish, you can also play with the `foo-head=ON`, `foo-git-branch=branchname` and no-options cases.  There is no change in behaviour here.

Staged docs:

https://www.openmicroscopy.org/site/support/ome-files-cpp-staging/ome-cmake-superbuild/manual/html/building.html#building-ome-qtwidgets-on-unix-development-specific-branches
https://www.openmicroscopy.org/site/support/ome-files-cpp-staging/ome-cmake-superbuild/manual/html/building.html#building-ome-qtwidgets-on-windows-development-specific-branches
