### PR TITLE
scripts: Handle ome-xml and ome-model names

### DIFF
--- a/scripts/jenkins-build
+++ b/scripts/jenkins-build
@@ -189,7 +189,7 @@ build() {
     rm -rf "${installdir}/${bundle_name}"
     mv "${installdir}/stage" "${installdir}/${bundle_name}"
 
-    for component in ome-common ome-model ome-files ome-qtwidgets ome-cmake-superbuild; do
+    for component in ome-common ome-model ome-xml ome-files ome-qtwidgets ome-cmake-superbuild; do
         if [ -d "${builddir}/stage/share/doc/${component}" ]; then
             mkdir -p "${installdir}/${docs_bundle_name}"
             echo "Installing documentation for ${component}"

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -440,7 +440,7 @@ if exist "%version_tag%" rmdir /s /q "%version_tag%"
 rename stage %version_tag%
 
 mkdir "%installdir%\%docs_version_tag%"
-for %%C in (ome-common,ome-model,ome-files,ome-qtwidgets,ome-cmake-superbuild) do (
+for %%C in (ome-common,ome-model,ome-xml,ome-files,ome-qtwidgets,ome-cmake-superbuild) do (
     if exist "%builddir%\stage\share\doc\%%C" (
         echo Installing documentation for %%C
         (robocopy "%builddir%\stage\share\doc\%%C" "%installdir%\%docs_version_tag%\%%C" /e >nul) ^& IF %ERRORLEVEL% GTR 3 exit /b


### PR DESCRIPTION
Testing:

- Check staging docs; you should get an `ome-model` manual link which links to the migrated formats docs.
- Check all C++ jobs are green.