### PR TITLE
ome-files-py: add PYTHONPATH element from the cache

### DIFF
--- a/helpers/cmake_environment.cmake
+++ b/helpers/cmake_environment.cmake
@@ -18,7 +18,8 @@ if(WIN32)
        "${OME_EP_TOOL_CACHE}/*/*/site-packages"
        "${OME_EP_TOOL_DIR}/*/site-packages"
        "${OME_EP_TOOL_DIR}/*/*/site-packages"
-       "${OME_EP_LIB_DIR}/*/site-packages")
+       "${OME_EP_LIB_DIR}/*/site-packages"
+       "${OME_EP_BUILD_CACHE}/lib/*/site-packages")
   foreach(dir ${python_dirs})
     file(TO_NATIVE_PATH "${dir}" dir)
     if(PYTHONPATH)
@@ -53,7 +54,8 @@ else()
        "${OME_EP_TOOL_CACHE}/*/*/site-packages"
        "${OME_EP_TOOL_DIR}/*/site-packages"
        "${OME_EP_TOOL_DIR}/*/*/site-packages"
-       "${OME_EP_LIB_DIR}/*/site-packages")
+       "${OME_EP_LIB_DIR}/*/site-packages"
+       "${OME_EP_BUILD_CACHE}/lib/*/site-packages")
   foreach(dir ${python_dirs})
     if(PYTHONPATH)
       set(PYTHONPATH "${dir}:${PYTHONPATH}")


### PR DESCRIPTION
Attempts to address an issue where `ome-files-py` tests are skipped in the superbuild (despite being executed in the platform builds).