### PR TITLE
ome-files-py: add lib64 paths to PYTHONPATH

### DIFF
--- a/helpers/cmake_environment.cmake
+++ b/helpers/cmake_environment.cmake
@@ -18,8 +18,7 @@ if(WIN32)
        "${OME_EP_TOOL_CACHE}/*/*/site-packages"
        "${OME_EP_TOOL_DIR}/*/site-packages"
        "${OME_EP_TOOL_DIR}/*/*/site-packages"
-       "${OME_EP_INSTALL_DIR}/lib/*/site-packages"
-       "${OME_EP_INSTALL_DIR}/lib64/*/site-packages")
+       "${OME_EP_INSTALL_DIR}/*/*/site-packages")
   foreach(dir ${python_dirs})
     file(TO_NATIVE_PATH "${dir}" dir)
     if(PYTHONPATH)
@@ -54,8 +53,7 @@ else()
        "${OME_EP_TOOL_CACHE}/*/*/site-packages"
        "${OME_EP_TOOL_DIR}/*/site-packages"
        "${OME_EP_TOOL_DIR}/*/*/site-packages"
-       "${OME_EP_INSTALL_DIR}/lib/*/site-packages"
-       "${OME_EP_INSTALL_DIR}/lib64/*/site-packages")
+       "${OME_EP_INSTALL_DIR}/*/*/site-packages")
   foreach(dir ${python_dirs})
     if(PYTHONPATH)
       set(PYTHONPATH "${dir}:${PYTHONPATH}")

--- a/helpers/cmake_environment.cmake
+++ b/helpers/cmake_environment.cmake
@@ -18,7 +18,8 @@ if(WIN32)
        "${OME_EP_TOOL_CACHE}/*/*/site-packages"
        "${OME_EP_TOOL_DIR}/*/site-packages"
        "${OME_EP_TOOL_DIR}/*/*/site-packages"
-       "${OME_EP_LIB_DIR}/*/site-packages")
+       "${OME_EP_INSTALL_DIR}/lib/*/site-packages"
+       "${OME_EP_INSTALL_DIR}/lib64/*/site-packages")
   foreach(dir ${python_dirs})
     file(TO_NATIVE_PATH "${dir}" dir)
     if(PYTHONPATH)
@@ -53,7 +54,8 @@ else()
        "${OME_EP_TOOL_CACHE}/*/*/site-packages"
        "${OME_EP_TOOL_DIR}/*/site-packages"
        "${OME_EP_TOOL_DIR}/*/*/site-packages"
-       "${OME_EP_LIB_DIR}/*/site-packages")
+       "${OME_EP_INSTALL_DIR}/lib/*/site-packages"
+       "${OME_EP_INSTALL_DIR}/lib64/*/site-packages")
   foreach(dir ${python_dirs})
     if(PYTHONPATH)
       set(PYTHONPATH "${dir}:${PYTHONPATH}")

--- a/packages/ome-files-py/build.cmake
+++ b/packages/ome-files-py/build.cmake
@@ -18,7 +18,7 @@ string(REPLACE ";" ":" INCLUDE_ARG "${INCLUDE_DIRS}")
 string(REPLACE ";" ":" LIB_ARG "${LIB_DIRS}")
 
 execute_process(COMMAND python setup.py build_ext
-  "-I${INCLUDE_ARG}" "-L${LIB_ARG}" "-R${LIB_ARG}"
+  "-I${INCLUDE_ARG}" "-L${LIB_ARG}"
   WORKING_DIRECTORY "${SOURCE_DIR}"
   RESULT_VARIABLE build_ext_result)
 if(build_ext_result)


### PR DESCRIPTION
Another attempt at fixing import errors in the superbuild (replaces #117).

On some platform (e.g., cowfish) ome-files-py is installed in `build/stage/lib64`, so we have to take that into account when setting the `PYTHONPATH`.