### PR TITLE
Bump source release versions for 0.3.0 release

### DIFF
--- a/packages/ome-files/superbuild.cmake
+++ b/packages/ome-files/superbuild.cmake
@@ -6,8 +6,8 @@ ome_source_settings(ome-files
   GIT_NAME        "ome-files-cpp"
   GIT_URL         "https://github.com/ome/ome-files-cpp.git"
   GIT_HEAD_BRANCH "master"
-  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-files-cpp/0.2.3/source/ome-files-cpp-0.2.3.tar.xz"
-  RELEASE_HASH    "SHA512=8d7cc123a3f32f363fb573529222f4d4c47dc16e8cc3f7a8e42a1592018971f4a8bf3c87b83ced3b4f5cda2dc58cdc7a40bf8b9215fe2b02ace9b589b04ab635")
+  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-files-cpp/0.3.0/source/ome-files-cpp-0.3.0.tar.xz"
+  RELEASE_HASH    "SHA512=6e86f42675470bc0e853eef02627838c24199c09c489cba3946dedb059fe68a18f9723bbd5c2ee0e4b74fcf7f74b262dd36576dd8b8ca43e21b1c6a00759a11b")
 
 # Set dependency list
 ome_add_dependencies(ome-files

--- a/packages/ome-model/superbuild.cmake
+++ b/packages/ome-model/superbuild.cmake
@@ -6,8 +6,8 @@ ome_source_settings(ome-model
   GIT_NAME        "ome-model"
   GIT_URL         "https://github.com/ome/ome-model.git"
   GIT_HEAD_BRANCH "master"
-  RELEASE_URL     ""
-  RELEASE_HASH    "SHA512=")
+  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-model/5.5.0/source/ome-model-5.5.0.tar.xz"
+  RELEASE_HASH    "SHA512=9ce0dc9343e854d4b3f547a5067bcab0e85ada90d238fc0300c539cbe4fb2bd0b65771efb56e34ce9108b56fa467a397bb0b27d22a5655d9c11e4682bc417ba2")
 
 # Set dependency list
 ome_add_dependencies(ome-model

--- a/packages/ome-qtwidgets/superbuild.cmake
+++ b/packages/ome-qtwidgets/superbuild.cmake
@@ -6,8 +6,8 @@ ome_source_settings(ome-qtwidgets
   GIT_NAME        "ome-qtwidgets"
   GIT_URL         "https://github.com/ome/ome-qtwidgets.git"
   GIT_HEAD_BRANCH "master"
-  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-qtwidgets/5.3.2/source/ome-qtwidgets-5.3.2.tar.xz"
-  RELEASE_HASH    "SHA512=ab9c3b745cdf409b977076853d227ccc65ca45b3977a373e65661f65ae101a2d11ff34328205bbc5693b219ef0b8f12f0536ef5652a7bb205e3f142e35bd1477")
+  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-qtwidgets/5.4.0/source/ome-qtwidgets-5.4.0.tar.xz"
+  RELEASE_HASH    "SHA512=8c5a92e90be6be0ecc3e30bd21ca1649c0f9daa6b2168cc4f1287c78f52634b6d723fce7a323831ee55da8d283475f3865fa99c5e584d148fae70cb7a2ff4c9b")
 
 # Set dependency list
 ome_add_dependencies(ome-qtwidgets


### PR DESCRIPTION
Update ome-model package for initial 5.5.0 source release, and also update ome-files to 0.3.0 and ome-qtwidgets to 5.4.0.

@sbesson Tested locally, should be safe to re-enable the sourcebuild job now.  It might need resynching with any of the superbuild job changes which were made since it got disabled (if any).