### PR TITLE
Bump ome-model version to 5.5.1 in the superbuild

### DIFF
--- a/packages/ome-model/superbuild.cmake
+++ b/packages/ome-model/superbuild.cmake
@@ -6,8 +6,8 @@ ome_source_settings(ome-model
   GIT_NAME        "ome-model"
   GIT_URL         "https://github.com/ome/ome-model.git"
   GIT_HEAD_BRANCH "master"
-  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-model/5.5.0/source/ome-model-5.5.0.tar.xz"
-  RELEASE_HASH    "SHA512=9ce0dc9343e854d4b3f547a5067bcab0e85ada90d238fc0300c539cbe4fb2bd0b65771efb56e34ce9108b56fa467a397bb0b27d22a5655d9c11e4682bc417ba2")
+  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-model/5.5.1/source/ome-model-5.5.1.tar.xz"
+  RELEASE_HASH    "SHA512=331cee0a3f9c2d144316236be7a9e4978108ea6838ae290a8e9e587f780ec512317232ae9f0b16fa49ae7223b74f6a522394e2fc2e50d597dce8e2f951f18ac5")
 
 # Set dependency list
 ome_add_dependencies(ome-model


### PR DESCRIPTION
Should include the OME-XML changes https://github.com/ome/ome-model/pull/30 into the superbuild infrastructure.

@rleigh-codelibre I assume I should open a corresponding ome-files-cpp change to https://github.com/ome/ome-files-cpp/blob/master/CMakeLists.txt#L105 to bump the minimal required version of ome-model?