### PR TITLE
Apply the same conditional copying of cached sources as cached tools

### DIFF
--- a/scripts/jenkins-build
+++ b/scripts/jenkins-build
@@ -246,8 +246,12 @@ build() {
     )
 
     # Archive sources
-    mkdir -p "${artefactdir}/sources"
-    cp -a ${cachedir}/source/* "${artefactdir}/sources"
+    if [ -d "${cachedir}/sources" ]; then
+        mkdir -p "${artefactdir}/sources"
+        find "${cachedir}/sources" -maxdepth 1 | while read file; do
+            cp -a "$file" "${artefactdir}/sources"
+        done
+    fi
     if [ -d "${cachedir}/tools" ]; then
         mkdir -p "${artefactdir}/tools"
         find "${cachedir}/tools" -maxdepth 1 | while read file; do


### PR DESCRIPTION
Platform builds have started failing recently since there is no more sources
in the cache. This commit copies the logic used for the cache tools and should
prevent failures if no source exists.

The expectation is that this will fix https://ci.openmicroscopy.org/view/Failing/job/OME-FILES-CPP-DEV-merge/