### PR TITLE
Fix name of archived source folder and duplication bug

### DIFF
--- a/scripts/jenkins-build
+++ b/scripts/jenkins-build
@@ -248,13 +248,13 @@ build() {
     # Archive sources
     if [ -d "${cachedir}/source" ]; then
         mkdir -p "${artefactdir}/sources"
-        find "${cachedir}/source" -maxdepth 1 | while read file; do
+        find "${cachedir}/source" -type f -maxdepth 1 | while read file; do
             cp -a "$file" "${artefactdir}/sources"
         done
     fi
     if [ -d "${cachedir}/tools" ]; then
         mkdir -p "${artefactdir}/tools"
-        find "${cachedir}/tools" -maxdepth 1 | while read file; do
+        find "${cachedir}/tools" -type f -maxdepth 1 | while read file; do
             cp -a "$file" "${artefactdir}/tools"
         done
     fi

--- a/scripts/jenkins-build
+++ b/scripts/jenkins-build
@@ -246,9 +246,9 @@ build() {
     )
 
     # Archive sources
-    if [ -d "${cachedir}/sources" ]; then
+    if [ -d "${cachedir}/source" ]; then
         mkdir -p "${artefactdir}/sources"
-        find "${cachedir}/sources" -maxdepth 1 | while read file; do
+        find "${cachedir}/source" -maxdepth 1 | while read file; do
             cp -a "$file" "${artefactdir}/sources"
         done
     fi


### PR DESCRIPTION
Fixes an issue introduced in dbf438461a3d5807d0702ca6646b5c63b036b68a. The names of the source folders in the cache and artifacts directories do not match exactly. With this commit third-party sources should be archived again in the artifacts of the merge superbuild.

See https://ci.openmicroscopy.org/job/OME-FILES-CPP-DEV-merge-superbuild/BUILD_TYPE=Release,node=cowfish/537/artifact/artefacts/sources/ for a reproduction of the initial issue (which causes the release jobs to fail).

To test this PR, review the artifacts of OME-FILES-CPP-DEV-merge-superbuild and OME-FILES-CPP-DEV-merge. There should be a flattened list of bundles with no subfolder under `artefacts/sources` and `artefacts/tools` (superbuild only).