### PR TITLE
OME Files C++ 0.4.0: dependency bumps (part 1)

### DIFF
--- a/packages/ome-common/superbuild.cmake
+++ b/packages/ome-common/superbuild.cmake
@@ -6,8 +6,8 @@ ome_source_settings(ome-common
   GIT_NAME        "ome-common-cpp"
   GIT_URL         "https://github.com/ome/ome-common-cpp.git"
   GIT_HEAD_BRANCH "master"
-  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-common-cpp/5.4.0/source/ome-common-cpp-5.4.0.tar.xz"
-  RELEASE_HASH    "SHA512=f14e808bda3f62240c4d345adfabd96ce39fdb7b338356aa9b702a8cefdc58ad544884d617b66e8e8f3398ea4f49705d0490d72baa36898acea11075c330efcd")
+  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-common-cpp/5.4.1/source/ome-common-cpp-5.4.1.tar.xz"
+  RELEASE_HASH    "SHA512=f455f68def8baf784feb9f5d0de808f6f0df65507913fb817130a1871a5709ef4610bb387f9d57bea4a9f5e83d7e43b0ba7d9d897d240924f549b75289e44dfe")
 
 # Set dependency list
 ome_add_dependencies(ome-common THIRD_PARTY_DEPENDENCIES boost gtest xerces xalan)

--- a/packages/ome-model/superbuild.cmake
+++ b/packages/ome-model/superbuild.cmake
@@ -6,8 +6,8 @@ ome_source_settings(ome-model
   GIT_NAME        "ome-model"
   GIT_URL         "https://github.com/ome/ome-model.git"
   GIT_HEAD_BRANCH "master"
-  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-model/5.5.1/source/ome-model-5.5.1.tar.xz"
-  RELEASE_HASH    "SHA512=331cee0a3f9c2d144316236be7a9e4978108ea6838ae290a8e9e587f780ec512317232ae9f0b16fa49ae7223b74f6a522394e2fc2e50d597dce8e2f951f18ac5")
+  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-model/5.5.3/source/ome-model-5.5.3.tar.xz"
+  RELEASE_HASH    "SHA512=6c29aa82d7e7088ef5497aeca1c75b9542223d18423e728fbaf4f6b28be15cff78caa7e4b9c1b31d0e03f5ceca3239a4f8562151be4c56e83874a470bb19d4f9")
 
 # Set dependency list
 ome_add_dependencies(ome-model

--- a/packages/ome-qtwidgets/superbuild.cmake
+++ b/packages/ome-qtwidgets/superbuild.cmake
@@ -6,8 +6,8 @@ ome_source_settings(ome-qtwidgets
   GIT_NAME        "ome-qtwidgets"
   GIT_URL         "https://github.com/ome/ome-qtwidgets.git"
   GIT_HEAD_BRANCH "master"
-  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-qtwidgets/5.4.0/source/ome-qtwidgets-5.4.0.tar.xz"
-  RELEASE_HASH    "SHA512=8c5a92e90be6be0ecc3e30bd21ca1649c0f9daa6b2168cc4f1287c78f52634b6d723fce7a323831ee55da8d283475f3865fa99c5e584d148fae70cb7a2ff4c9b")
+  RELEASE_URL     "https://downloads.openmicroscopy.org/ome-qtwidgets/5.4.1/source/ome-qtwidgets-5.4.1.tar.xz"
+  RELEASE_HASH    "SHA512=4d5e3be7de713e27adbfcaa31d9267217ad07a9c62472be25ebe163634fe10790b53882c1ada665cd2cda1a5e4e55d1c32d7c63017faaff71a6b908fbc2676b9")
 
 # Set dependency list
 ome_add_dependencies(ome-qtwidgets


### PR DESCRIPTION
As components are getting released, this PR bumps the source releases of the following packages:

- `ome-common-cpp` to 5.4.1
- `ome-model` to 5.5.3
- `ome-qtwidgets` to 5.4.1