### PR TITLE
cmake: Use C++ standard variables as documented

### DIFF
--- a/Options.cmake
+++ b/Options.cmake
@@ -83,8 +83,8 @@ option(sphinx "Enable sphinx manual page and HTML documentation" ON)
 option(sphinx-linkcheck "Check sphinx documentation links by default" OFF)
 
 # C++ standard
-set(CMAKE_CXX_STANDARD "14" CACHE STRING "Preferred C++ standard version")
-set(CMAKE_CXX_STANDARD_REQUIRED "11" CACHE STRING "Minimum C++ standard version")
+set(CMAKE_CXX_STANDARD "14" CACHE STRING "Preferred C++ standard version (will fall back to earlier versions if unavailable)")
+set(CMAKE_CXX_STANDARD_REQUIRED FALSE CACHE BOOL "Force use of specified C++ standard (no fallback to earlier versions)")
 
 set(SUPERBUILD_OPTIONS
     "-Dextra-warnings:BOOL=${extra-warnings}"


### PR DESCRIPTION
See [trello card](https://trello.com/c/0JzeUNqd/38-correct-use-of-cmake-standard-version-selection-variables).

Testing: check builds are green; there's no behaviour change here.