### PR TITLE
docs: sphinx: Use master as the source branch

### DIFF
--- a/docs/sphinx/building.rst
+++ b/docs/sphinx/building.rst
@@ -103,7 +103,7 @@ fatal-warnings=(ON|OFF)
   Make compiler warnings into fatal errors.  This is disabled by
   default.
 head=(ON|OFF)
-  Force building from the current git ``develop`` branch.  Disabled by
+  Force building from the current git ``master`` branch.  Disabled by
   default.  :program:`git` is required to clone the repositories if
   enabled.
 parallel=(ON|OFF)

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -40,7 +40,7 @@ extensions = ['sphinx.ext.extlinks', 'edit_on_github']
 
 ## Configuration for the edit_on_github extension
 edit_on_github_project = 'ome/ome-cmake-superbuild'
-edit_on_github_branch = 'develop'
+edit_on_github_branch = 'master'
 edit_on_github_prefix = 'docs/sphinx'
 
 # Add any paths that contain templates here, relative to this directory.
@@ -105,7 +105,7 @@ pygments_style = 'sphinx'
 #modindex_common_prefix = []
 
 # Variables used to define Github extlinks
-source_branch = 'develop'
+source_branch = 'master'
 if (ext_source_branch is not None and len(ext_source_branch) > 0 and
     ext_source_branch != "@%s@" % ('sphinx_source_branch')):
     source_branch = ext_source_branch


### PR DESCRIPTION
Testing: Check edit on github links; should use the master branch.

See e.g. http://www.openmicroscopy.org/site/support/ome-files-cpp-staging/ome-cmake-superbuild/manual/html/index.html