### PR TITLE
Add ome-files-performance as a superbuild component

### DIFF
--- a/packages/ome-files-performance/README.md
+++ b/packages/ome-files-performance/README.md
@@ -1,0 +1,36 @@
+# ome-files-performance build
+
+Changes made locally
+--------------------
+
+* None
+
+License
+-------
+
+```
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are
+those of the authors and should not be interpreted as representing official
+policies, either expressed or implied, of any organization.
+```

--- a/packages/ome-files-performance/superbuild.cmake
+++ b/packages/ome-files-performance/superbuild.cmake
@@ -1,0 +1,59 @@
+# ome-files-performance superbuild
+
+# Source information
+ome_source_settings(ome-files-performance
+  NAME            "OME Files Performance"
+  GIT_NAME        "ome-files-performance"
+  GIT_URL         "https://github.com/openmicroscopy/ome-files-performance.git"
+  GIT_HEAD_BRANCH "master"
+  RELEASE_URL     ""
+  RELEASE_HASH    "")
+
+# Set dependency list
+ome_add_dependencies(ome-files-performance
+                     DEPENDENCIES ome-files
+                     THIRD_PARTY_DEPENDENCIES boost)
+
+list(APPEND CONFIGURE_OPTIONS
+     "-DBOOST_ROOT=${OME_EP_INSTALL_DIR}"
+     -DBoost_NO_BOOST_CMAKE:BOOL=true
+     ${SUPERBUILD_OPTIONS})
+if(SOURCE_ARCHIVE_DIR)
+  list(APPEND CONFIGURE_OPTIONS "-DSOURCE_ARCHIVE_DIR=${SOURCE_ARCHIVE_DIR}")
+endif()
+string(REPLACE ";" "^^" CONFIGURE_OPTIONS "${CONFIGURE_OPTIONS}")
+
+ExternalProject_Add(${EP_PROJECT}
+  ${OME_EP_COMMON_ARGS}
+  ${EP_SOURCE_DOWNLOAD}
+  SOURCE_DIR ${EP_SOURCE_DIR}
+  BINARY_DIR ${EP_BINARY_DIR}
+  INSTALL_DIR ""
+  CONFIGURE_COMMAND ${CMAKE_COMMAND}
+    "-DSOURCE_DIR:PATH=${EP_SOURCE_DIR}"
+    "-DBUILD_DIR:PATH=${EP_BINARY_DIR}"
+    "-DCONFIGURE_OPTIONS=${CONFIGURE_OPTIONS}"
+    "-DCONFIG:INTERNAL=$<CONFIG>"
+    "-DEP_SCRIPT_CONFIG:FILEPATH=${EP_SCRIPT_CONFIG}"
+    -P "${GENERIC_CMAKE_CONFIGURE}"
+  BUILD_COMMAND ${CMAKE_COMMAND}
+    "-DSOURCE_DIR:PATH=${EP_SOURCE_DIR}"
+    "-DBUILD_DIR:PATH=${EP_BINARY_DIR}"
+    "-DCONFIG:INTERNAL=$<CONFIG>"
+    "-DEP_SCRIPT_CONFIG:FILEPATH=${EP_SCRIPT_CONFIG}"
+    -P "${GENERIC_CMAKE_BUILD}"
+  INSTALL_COMMAND ${CMAKE_COMMAND}
+    "-DSOURCE_DIR:PATH=${EP_SOURCE_DIR}"
+    "-DBUILD_DIR:PATH=${EP_BINARY_DIR}"
+    "-DCONFIG:INTERNAL=$<CONFIG>"
+    "-DEP_SCRIPT_CONFIG:FILEPATH=${EP_SCRIPT_CONFIG}"
+    -P "${GENERIC_CMAKE_INSTALL}"
+  TEST_COMMAND ${CMAKE_COMMAND}
+    "-DSOURCE_DIR:PATH=${EP_SOURCE_DIR}"
+    "-DBUILD_DIR:PATH=${EP_BINARY_DIR}"
+    "-DCONFIG:INTERNAL=$<CONFIG>"
+    "-DEP_SCRIPT_CONFIG:FILEPATH=${EP_SCRIPT_CONFIG}"
+    -P "${GENERIC_CMAKE_TEST}"
+  DEPENDS
+    ${EP_PROJECT}-prerequisites
+  )

--- a/scripts/jenkins-build
+++ b/scripts/jenkins-build
@@ -118,7 +118,7 @@ build() {
 
     GIT_OPTIONS=
     if [ "$build_git" = "ON" ];then
-        GIT_OPTIONS="-Dome-model-dir=${workspace}/ome-model -Dome-files-dir=${workspace}/ome-files -Dome-common-dir=${workspace}/ome-common -Dome-qtwidgets-dir=${workspace}/ome-qtwidgets -Dome-files-py-dir=${workspace}/ome-files-py"
+        GIT_OPTIONS="-Dome-model-dir=${workspace}/ome-model -Dome-files-dir=${workspace}/ome-files -Dome-common-dir=${workspace}/ome-common  -Dome-files-performance-dir=${workspace}/ome-files-performance -Dome-qtwidgets-dir=${workspace}/ome-qtwidgets -Dome-files-py-dir=${workspace}/ome-files-py"
     fi
 
     rm -rf "$builddir" "$installdir"
@@ -315,6 +315,7 @@ Options:
   -j n       Build in parallel
   -P         Enable paralellism in subsidiary builds
   -N n       Build number
+  -F         Build performance tests
   -q         Build Qt interface
   -W         Build Python wrapper
   -v         Verbose build
@@ -359,6 +360,9 @@ while getopts hBGqWndLexvPi:b:c:a:g:N:p:t:S:w:s:j: OPT; do
             ;;
         n)
             build_tp_prereqs=OFF
+            ;;
+        F)
+            build_packages="${build_packages};ome-files-performance"
             ;;
         q)
             build_packages="${build_packages};ome-qtwidgets"

--- a/scripts/jenkins-build.bat
+++ b/scripts/jenkins-build.bat
@@ -34,6 +34,7 @@ set parallel_opt=OFF
 set build_git=OFF
 set action=build
 set qt=OFF
+set perf=OFF
 set "packages=ome-files;ome-cmake-superbuild-docs;ome-cmake-superbuild-docs-contents"
 
 REM Parse command line options.
@@ -47,6 +48,10 @@ if NOT "%1"=="" (
     )
     if "%1"=="-G" (
         set "build_git=ON"
+    )
+    if "%1"=="-F" (
+        set "perf=ON"
+        set "packages=%packages%;ome-files-performance"
     )
     if "%1"=="-q" (
         set "qt=ON"
@@ -163,6 +168,7 @@ echo verbose=%verbose%
 echo parallel=%parallel%
 echo build_git=%build_git%
 echo qt=%qt%
+echo perf=%perf%
 
 goto main
 
@@ -195,6 +201,7 @@ Options:
   -d         Build doxygen API reference
   -L         Run sphinx link checks
   -e         Run extended tests
+  -F         Build performance tests
   -q         Build Qt interface
   -j n       Build in parallel
   -P         Enable paralellism in subsidiary builds
@@ -288,7 +295,7 @@ if exist "%cachedir%\tree" (
 )
 
 if [%build_git%] == [ON] (
-    set "GIT_OPTIONS=-Dome-model-dir=%workspace%\ome-model -Dome-files-dir=%workspace%\ome-files -Dome-common-dir=%workspace%\ome-common -Dome-qtwidgets-dir=%workspace%\ome-qtwidgets"
+    set "GIT_OPTIONS=-Dome-model-dir=%workspace%\ome-model -Dome-files-dir=%workspace%\ome-files -Dome-common-dir=%workspace%\ome-common -Dome-files-performance-dir=%workspace%\ome-files-performance -Dome-qtwidgets-dir=%workspace%\ome-qtwidgets"
 )
 
 if [%qt%] == [ON] (


### PR DESCRIPTION
As for ome-files-py, it's git-only and unversioned.

Requires the following infrastructure changes:

- The CI merge jobs need to add the ome-files-performance git repository as done for ome-files-py
- The CI merge jobs need to add an `-F` option to enable building the performance tests

To test locally:

Run `cmake -Dbuild-packages=ome-files-performance [-Dbuild-prerequisites=OFF]` and it will build ome-files plus the performance tests.  You'll find them in `stage/bin`.