### PR TITLE
Bump version number to 0.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/Options.cmake")
 
 set(release-name "ome-cmake-superbuild")
-set(release-version "0.3.2")
+set(release-version "0.4.0")
 project("${release-name}"
   VERSION "${release-version}"
   LANGUAGES CXX)


### PR DESCRIPTION
Version bump to create the source release of `ome-cmake-superbuild` 0.4.0