### PR TITLE
cmake: Make the C++ language standard version configurable

### DIFF
--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -84,9 +84,6 @@ option(sphinx-linkcheck "Check sphinx documentation links by default" OFF)
 
 # C++ standard
 set(default_cxx_standard 14)
-if(NOT CMAKE_VERSION VERSION_LESS 3.8)
-  set(default_cxx_standard 17)
-endif()
 set(CMAKE_CXX_STANDARD "${default_cxx_standard}" CACHE STRING "Preferred C++ standard version (will fall back to earlier versions if unavailable)")
 set(CMAKE_CXX_STANDARD_REQUIRED FALSE CACHE BOOL "Force use of specified C++ standard (no fallback to earlier versions)")
 

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -83,7 +83,11 @@ option(sphinx "Enable sphinx manual page and HTML documentation" ON)
 option(sphinx-linkcheck "Check sphinx documentation links by default" OFF)
 
 # C++ standard
-set(CMAKE_CXX_STANDARD "17" CACHE STRING "Preferred C++ standard version (will fall back to earlier versions if unavailable)")
+set(default_cxx_standard 14)
+if(NOT CMAKE_VERSION VERSION_LESS 3.8)
+  set(default_cxx_standard 17)
+endif()
+set(CMAKE_CXX_STANDARD "${default_cxx_standard}" CACHE STRING "Preferred C++ standard version (will fall back to earlier versions if unavailable)")
 set(CMAKE_CXX_STANDARD_REQUIRED FALSE CACHE BOOL "Force use of specified C++ standard (no fallback to earlier versions)")
 
 set(SUPERBUILD_OPTIONS

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -83,7 +83,7 @@ option(sphinx "Enable sphinx manual page and HTML documentation" ON)
 option(sphinx-linkcheck "Check sphinx documentation links by default" OFF)
 
 # C++ standard
-set(CMAKE_CXX_STANDARD "14" CACHE STRING "Preferred C++ standard version (will fall back to earlier versions if unavailable)")
+set(CMAKE_CXX_STANDARD "17" CACHE STRING "Preferred C++ standard version (will fall back to earlier versions if unavailable)")
 set(CMAKE_CXX_STANDARD_REQUIRED FALSE CACHE BOOL "Force use of specified C++ standard (no fallback to earlier versions)")
 
 set(SUPERBUILD_OPTIONS

--- a/docs/sphinx/packages/toolchain.rst
+++ b/docs/sphinx/packages/toolchain.rst
@@ -5,9 +5,9 @@ Basic toolchain
 
 A functional compiler, assembler and linker are required to build C++
 code.  The C++ compiler must support the C++11 standard at a minimum,
-with selected C++14 features such as make_unique.  Optional C++14 and
-C++17 features will be enabled if the compiler supports them, otherwise
-Boost will be used to provide equivalent functionality.
+with selected C++14 features such as make_unique.  Optional C++14
+features will be enabled if the compiler supports them, otherwise Boost
+will be used to provide equivalent functionality.
 
 +------------------+-----------------+
 | System           | Package         |

--- a/docs/sphinx/packages/toolchain.rst
+++ b/docs/sphinx/packages/toolchain.rst
@@ -5,7 +5,9 @@ Basic toolchain
 
 A functional compiler, assembler and linker are required to build C++
 code.  The C++ compiler must support the C++11 standard at a minimum,
-with the C++14 standard being preferred.
+with selected C++14 features such as make_unique.  Optional C++14 and
+C++17 features will be enabled if the compiler supports them, otherwise
+Boost will be used to provide equivalent functionality.
 
 +------------------+-----------------+
 | System           | Package         |


### PR DESCRIPTION
See [trello](https://trello.com/c/76T69NA9/4-c14-and-17-support) for rationale.  See also referenced PRs.

Testing: Check builds remain green.  In this initial set of PRs, no C++14 or 17 features are used.  This is purely an update to the build infrastructure.