### PR TITLE
Docs: Python as an explicit prerequisite

### DIFF
--- a/docs/sphinx/packages/python2.rst
+++ b/docs/sphinx/packages/python2.rst
@@ -17,8 +17,13 @@ The Python language intepreter, version 2.
 | RedHat/CentOS    | python      |
 +------------------+-------------+
 
+**Note:** the super-build requires the *development* version of
+Python, which provides the Python headers. In some systems, this is
+installed as a separate package, e.g., ``python-dev`` in Debian/Ubuntu
+and ``python-devel`` in CentOS.
+
 - `Website <https://www.python.org/>`__
-- `Download <https://www.python.org/downloads/release/python-2711>`__
+- `Download <https://www.python.org/downloads/release/python-2713>`__
 
 Windows
 ^^^^^^^

--- a/docs/sphinx/prerequisites.rst
+++ b/docs/sphinx/prerequisites.rst
@@ -9,26 +9,24 @@ building, shown in the table below.
 
 .. tabularcolumns:: |l|l|l|c|c|c|
 
-+---------------+--------------+--------------+--------------------------------------+
-|               |           Version           |             When required            |
-+---------------+--------------+--------------+--------------+--------------+--------+
-| Package       | Recommended  | Minimum      | Source build | Client build | Deploy |
-+===============+==============+==============+==============+==============+========+
-| Toolchain     |              |              |    \•        | \•           |        |
-+---------------+--------------+--------------+--------------+--------------+--------+
-| CMake         | 3.5          | 3.2          |    \•        | \•           |        |
-+---------------+--------------+--------------+--------------+--------------+--------+
-| Git           | 2.9.x        | 1.7.x        |    ◦         | ◦            |        |
-+---------------+--------------+--------------+--------------+--------------+--------+
++----------------------+--------------+--------------+--------------------------------------+
+|                      |           Version           |             When required            |
++----------------------+--------------+--------------+--------------+--------------+--------+
+| Package              | Recommended  | Minimum      | Source build | Client build | Deploy |
++======================+==============+==============+==============+==============+========+
+| :ref:`pkg_toolchain` |              |              |    \•        | \•           |        |
++----------------------+--------------+--------------+--------------+--------------+--------+
+| :ref:`pkg_cmake`     | 3.5          | 3.2          |    \•        | \•           |        |
++----------------------+--------------+--------------+--------------+--------------+--------+
+| :ref:`pkg_python2`   | 2.7.13       | 2.7.x        |    \•        | \•           |        |
++----------------------+--------------+--------------+--------------+--------------+--------+
+| :ref:`pkg_git`       | 2.9.x        | 1.7.x        |    ◦         | ◦            |        |
++----------------------+--------------+--------------+--------------+--------------+--------+
 
 \•
   Required
 ◦
   Optional, needed only if building from a git repository
-
-:ref:`pkg_toolchain`
-:ref:`pkg_cmake`
-:ref:`pkg_git`
 
 Quick start
 -----------
@@ -43,14 +41,15 @@ Install the following:
 
 - :ref:`pkg_toolchain`
 - :ref:`pkg_cmake`
+- :ref:`pkg_python2`
 - :ref:`pkg_git`
 
 Examples:
 
 BSD Ports
-  ``pkg install cmake git``
+  ``pkg install cmake python git``
 Debian/Ubuntu
-  ``apt-get install build-essential cmake git``
+  ``apt-get install build-essential cmake python python-dev git``
 
 Homebrew and RedHat/CentOS do not provide packages for everything that
 is needed. The commands listed will install *most* of the
@@ -58,9 +57,9 @@ dependencies, but further dependencies will need to be installed as
 described in various sections below.
 
 Homebrew
-  Install Xcode, then ``brew install cmake git``
+  Install Xcode, then ``brew install cmake python git``
 RedHat/CentOS
-  ``yum groupinstall "Development Tools"``, then ``yum install git``;
+  ``yum groupinstall "Development Tools"``, then ``yum install python python-devel git``;
   install cmake by hand.
 
 Additional prerequisites


### PR DESCRIPTION
Although Python is often pre-installed in the Desktop versions of various operating systems, it can be missing in server installations or virtual machine images. This PR updates the docs to list Python as an explicit prerequisite. In addition, it moves the refs to individual package doc pages directly inside the table in `prerequisites.rst`.

To test, run `cd docs/sphinx; make html`

Check that the docs build without errors, then open `build/html/prerequisites.html` in your browser and check the rendering and links both in `prerequisites.html` itself and `packages/python2.html` (follow the "Python 2" link on the prerequisites table).