### PR TITLE
xerces: Use archive site URL

### DIFF
--- a/packages/xerces/superbuild.cmake
+++ b/packages/xerces/superbuild.cmake
@@ -5,7 +5,7 @@ ome_add_dependencies(xerces THIRD_PARTY_DEPENDENCIES patch icu)
 
 ExternalProject_Add(${EP_PROJECT}
   ${OME_EP_COMMON_ARGS}
-  URL "https://www.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.4.tar.xz"
+  URL "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.4.tar.xz"
   URL_HASH "SHA512=3e07f35f5fb8067cec1bd2973fb3c7acf0df5069f717eab6ffa581728292829d52d6d6f5186456718767264dc16e2d392a4493fbe4839c00fc3eef06ca84b495"
   SOURCE_DIR "${EP_SOURCE_DIR}"
   BINARY_DIR "${EP_BINARY_DIR}"


### PR DESCRIPTION
3.1.4 is no longer available on the main site.  Due to the release of 3.2.0.

Testing: Check superbuild jobs are green.