### PR TITLE
Remove sphinx-ignore-links repo from conf.py.in

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -360,13 +360,3 @@ linkcheck_timeout = 30
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = []
-try:
-    if sys.version_info[0] >= 3:
-        from urllib.request import urlopen
-    else:
-        from urllib import urlopen
-    brokenfiles_url = 'https://raw.github.com/openmicroscopy/sphinx-ignore-links/master/broken_links.txt'
-    brokenlinks = urlopen(brokenfiles_url)
-    linkcheck_ignore.extend(brokenlinks.read().splitlines())
-except IOError:
-    print("Could not open list of broken links.")


### PR DESCRIPTION
Re: https://github.com/openmicroscopy/sphinx-ignore-links/issues/1 this removes use of the external repo in favour of listing any links needing to be ignored in the conf.py.in in future.