### PR TITLE
tiff: Version 4.0.9

### DIFF
--- a/packages/tiff/superbuild.cmake
+++ b/packages/tiff/superbuild.cmake
@@ -4,8 +4,8 @@
 set(tiff-head OFF CACHE BOOL "Force building libtiff from current CVS head")
 
 # Current stable release.
-set(RELEASE_URL "http://download.osgeo.org/libtiff/tiff-4.0.8.tar.gz")
-set(RELEASE_HASH "SHA512=5d010ec4ce37aca733f7ab7db9f432987b0cd21664bd9d99452a146833c40f0d1e7309d1870b0395e947964134d5cfeb1366181e761fe353ad585803ff3d6be6")
+set(RELEASE_URL "http://download.osgeo.org/libtiff/tiff-4.0.9.tar.gz")
+set(RELEASE_HASH "SHA512=04f3d5eefccf9c1a0393659fe27f3dddd31108c401ba0dc587bca152a1c1f6bc844ba41622ff5572da8cc278593eff8c402b44e7af0a0090e91d326c2d79f6cd")
 
 # Current development branch (defaults for head option).
 set(CVS_REPOSITORY ":pserver:cvsanon@cvs.maptools.org:/cvs/maptools/cvsroot")


### PR DESCRIPTION
New upstream release, with a lot of security fixes.  [Changes](http://www.simplesystems.org/libtiff/v4.0.9.html): a bunch of build fixes and testing stuff by me, and a huge amount of overflow and other bugs fixed as a result of fuzzing and static analysis.

Testing: Builds should remain green.