### PR TITLE
ome-model: Update dependencies for python3

### DIFF
--- a/packages/ome-model/superbuild.cmake
+++ b/packages/ome-model/superbuild.cmake
@@ -14,7 +14,7 @@ ome_add_dependencies(ome-model
                      DEPENDENCIES ome-common
                      THIRD_PARTY_DEPENDENCIES boost png tiff xerces
                                               xalan gtest
-                     THIRD_PARTY_PYTHON2_DEPENDENCIES genshi sphinx)
+                     THIRD_PARTY_PYTHON2_DEPENDENCIES genshi sphinx six)
 
 list(APPEND CONFIGURE_OPTIONS
      "-DBOOST_ROOT=${OME_EP_INSTALL_DIR}"

--- a/packages/ome-model/superbuild.cmake
+++ b/packages/ome-model/superbuild.cmake
@@ -14,7 +14,7 @@ ome_add_dependencies(ome-model
                      DEPENDENCIES ome-common
                      THIRD_PARTY_DEPENDENCIES boost png tiff xerces
                                               xalan gtest
-                     THIRD_PARTY_PYTHON2_DEPENDENCIES genshi sphinx six)
+                     THIRD_PARTY_PYTHON2_DEPENDENCIES sphinx six)
 
 list(APPEND CONFIGURE_OPTIONS
      "-DBOOST_ROOT=${OME_EP_INSTALL_DIR}"


### PR DESCRIPTION
Related to https://github.com/ome/ome-model/pull/65

This doesn't actually add Python3 support, it rather adds support for the `six` module for future use of Python 3 features with Python 2.7 in the linked PR, and drops support for building with an external genshi (so we always use the fork provided by the ome-model repo).

This has been tested for 3½ months without any problems.